### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This step will pull the Regolith package metadata down from GitHub.  The debian 
 $ mkdir workspace
 
 $ git clone -b debian https://github.com/regolith-linux/regolith-st
+$ cd regolith-st/debian/
 ```
 
 ## Download and prepare the upstream source


### PR DESCRIPTION
the further steps either applying patches or pacakging are done from `/path/to/workspace/regolith-st/debian/` directory and it's not mentioned. Downloading the original package source code and extracting it and moving it from ../ into root … makes some confusion if the current working directory is not mentioned!